### PR TITLE
save-payload-to-mpl-attachment-with-log-level.groovy

### DIFF
--- a/mpl-payload-log-with-loglevel/save-payload-to-mpl-attachment-with-log-level.groovy
+++ b/mpl-payload-log-with-loglevel/save-payload-to-mpl-attachment-with-log-level.groovy
@@ -1,0 +1,12 @@
+import com.sap.gateway.ip.core.customdev.util.Message
+
+Message processData(Message message) {
+
+    String logLevel = message.getProperty('SAP_MessageProcessingLogConfiguration').logLevel.toString()
+
+    if (logLevel in ['DEBUG', 'TRACE']) {
+        messageLogFactory.getMessageLog(message)?.addAttachmentAsString('Message body', message.getBody(String), 'text/plain')
+    }
+
+    return message
+}


### PR DESCRIPTION
An alternative implementation of a Groovy script to save a message payload as an MPL attachment for specific MPL log levels.