### PR TITLE
save-payload-to-mpl-attachment-with-log-level.groovy: Use properties SAP_MPL_LogLevel_*

### DIFF
--- a/mpl-payload-log-with-loglevel/save-payload-to-mpl-attachment-with-log-level.groovy
+++ b/mpl-payload-log-with-loglevel/save-payload-to-mpl-attachment-with-log-level.groovy
@@ -2,7 +2,7 @@ import com.sap.gateway.ip.core.customdev.util.Message
 
 Message processData(Message message) {
 
-    String logLevel = message.getProperty('SAP_MessageProcessingLogConfiguration').logLevel.toString()
+    String logLevel = message.getProperty('SAP_MPL_LogLevel_Overall')
 
     if (logLevel in ['DEBUG', 'TRACE']) {
         messageLogFactory.getMessageLog(message)?.addAttachmentAsString('Message body', message.getBody(String), 'text/plain')


### PR DESCRIPTION
To determine a log level during message processing using a Groovy script, it is now recommended to retrieve it from exchange properties `SAP_MPL_LogLevel_*` (`SAP_MPL_LogLevel_Internal`, `SAP_MPL_LogLevel_External` and `SAP_MPL_LogLevel_Overall`) as opposed to deriving it from the exchange property `SAP_MessageProcessingLogConfiguration`.

More information and details about this:

- [SAP Cloud Integration documentation](https://help.sap.com/docs/cloud-integration/sap-cloud-integration/setting-log-levels),
- [Contributions to SAP Integration Suite documentation - issue _Documenting how to get the current log level_](https://github.com/SAP-docs/btp-integration-suite/issues/23).